### PR TITLE
Install to devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ incorrect usage get highlighted in the UI.
 
 ## Installation
 
-    $ bower install --save nudgecss
+    $ bower install --save-dev nudgecss
 
 Or:
 
-    $ npm install --save nudgecss
+    $ npm install --save-dev nudgecss
 
 ## Disclaimers and Notices
 


### PR DESCRIPTION
Hey Harry,

Was just reading the docs and saw this bit:

> Remove Nudge from production. Nudge will fill your stylesheet full of crap: please make sure you remove Nudge before putting any CSS live. This will help performance, but will also ensure that your users never see any errors or breakages that your developers have missed.

Yet under the installation instructions we are installing nudge to dependencies (using `--save`), rather than devDependencies (using `--save-dev`), meaning nudge will be included on a production build.

It won't make any difference really as people won't (or shouldn't 😮) be using this in production, but it will avoid some redundant files being created and hopefully help improve clarity between this being a development tool rather than something run in a production build.

What do you reckon?
